### PR TITLE
Update templates year from 2025 to 2026 (#34)

### DIFF
--- a/src/main/resources/templates/adoption.ftl
+++ b/src/main/resources/templates/adoption.ftl
@@ -38,7 +38,7 @@
        </tr>
        <tr>
          <td align="center" style="color: white; font-size: 14px;">
-           <span>&#169;</span> Copyright 2025, Vetlog.
+           <span>&#169;</span> Copyright 2026, Vetlog.
          </td>
        </tr>
        <tr>

--- a/src/main/resources/templates/adoption_es.ftl
+++ b/src/main/resources/templates/adoption_es.ftl
@@ -38,7 +38,7 @@
         </tr>
         <tr>
           <td align="center" style="color: white; font-size: 14px;">
-            <span>&#169;</span> Copyright 2025, Vetlog.
+            <span>&#169;</span> Copyright 2026, Vetlog.
           </td>
         </tr>
         <tr>

--- a/src/main/resources/templates/batch.html
+++ b/src/main/resources/templates/batch.html
@@ -33,7 +33,7 @@
   </div>
   <br>
   <footer class="pt-3 mt-4 text-body-secondary border-top">
-    <a class="navbar-brand" href="http://josdem.io">© 2025 - josdem.io</a>
+    <a class="navbar-brand" href="http://josdem.io">© 2026 - josdem.io</a>
   </footer>
 </body>
 </html>

--- a/src/main/resources/templates/command_line.html
+++ b/src/main/resources/templates/command_line.html
@@ -53,7 +53,7 @@
   </div>
   <br/>
   <footer class="pt-3 mt-4 text-body-secondary border-top">
-    <a class="navbar-brand" href="http://josdem.io">© 2025 - josdem.io</a>
+    <a class="navbar-brand" href="http://josdem.io">© 2026 - josdem.io</a>
   </footer>
 </body>
 </html>

--- a/src/main/resources/templates/contact.html
+++ b/src/main/resources/templates/contact.html
@@ -57,7 +57,7 @@
   </div>
   <br/>
   <footer class="pt-3 mt-4 text-body-secondary border-top">
-    <a class="navbar-brand" href="http://josdem.io">© 2025 - josdem.io</a>
+    <a class="navbar-brand" href="http://josdem.io">© 2026 - josdem.io</a>
   </footer>
 </body>
 </html>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -26,7 +26,7 @@
   </div>
   <br/>
     <footer class="pt-3 mt-4 text-body-secondary border-top">
-      <a class="navbar-brand" href="http://josdem.io">© 2025 - josdem.io</a>
+      <a class="navbar-brand" href="http://josdem.io">© 2026 - josdem.io</a>
     </footer>
   </body>
 </html>

--- a/src/main/resources/templates/flyer.html
+++ b/src/main/resources/templates/flyer.html
@@ -26,7 +26,7 @@
   </div>
   <br/>
     <footer class="pt-3 mt-4 text-body-secondary border-top">
-      <a class="navbar-brand" href="http://josdem.io">© 2025 - josdem.io</a>
+      <a class="navbar-brand" href="http://josdem.io">© 2026 - josdem.io</a>
     </footer>
   </body>
 </html>

--- a/src/main/resources/templates/forgotPassword.ftl
+++ b/src/main/resources/templates/forgotPassword.ftl
@@ -40,7 +40,7 @@
         </tr>
         <tr>
           <td align="center" style="color: white; font-size: 14px;">
-            <span>&#169;</span> Copyright 2025, Vetlog.
+            <span>&#169;</span> Copyright 2026, Vetlog.
           </td>
         </tr>
         <tr>

--- a/src/main/resources/templates/forgotPassword_es.ftl
+++ b/src/main/resources/templates/forgotPassword_es.ftl
@@ -40,7 +40,7 @@
         </tr>
         <tr>
           <td align="center" style="color: white; font-size: 14px;">
-            <span>&#169;</span> Copyright 2025, Vetlog.
+            <span>&#169;</span> Copyright 2026, Vetlog.
           </td>
         </tr>
         <tr>

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -58,7 +58,7 @@
   </div>
   <br/>
   <footer class="pt-3 mt-4 text-body-secondary border-top">
-    <a class="navbar-brand" href="http://josdem.io">© 2025 - josdem.io</a>
+    <a class="navbar-brand" href="http://josdem.io">© 2026 - josdem.io</a>
   </footer>
 </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -41,7 +41,7 @@
     </div>
 </div>
 <footer class="pt-3 mt-4 text-body-secondary border-top">
-    <a class="navbar-brand" href="http://josdem.io">© 2025 - josdem.io</a>
+    <a class="navbar-brand" href="http://josdem.io">© 2026 - josdem.io</a>
 </footer>
 </body>
 </html>

--- a/src/main/resources/templates/pullingUp.ftl
+++ b/src/main/resources/templates/pullingUp.ftl
@@ -36,7 +36,7 @@
     </tr>
     <tr>
       <td align="center" style="color: white; font-size: 14px;">
-        <span>&#169;</span> Copyright 2025, Vetlog.
+        <span>&#169;</span> Copyright 2026, Vetlog.
       </td>
     </tr>
     <tr>

--- a/src/main/resources/templates/pullingUp_es.ftl
+++ b/src/main/resources/templates/pullingUp_es.ftl
@@ -36,7 +36,7 @@
     </tr>
     <tr>
       <td align="center" style="color: white; font-size: 14px;">
-        <span>&#169;</span> Copyright 2025, Vetlog.
+        <span>&#169;</span> Copyright 2026, Vetlog.
       </td>
     </tr>
     <tr>

--- a/src/main/resources/templates/welcome.ftl
+++ b/src/main/resources/templates/welcome.ftl
@@ -36,7 +36,7 @@
     </tr>
     <tr>
       <td align="center" style="color: white; font-size: 14px;">
-        <span>&#169;</span> Copyright 2025, Vetlog.
+        <span>&#169;</span> Copyright 2026, Vetlog.
       </td>
     </tr>
     <tr>

--- a/src/main/resources/templates/welcome_es.ftl
+++ b/src/main/resources/templates/welcome_es.ftl
@@ -36,7 +36,7 @@
     </tr>
     <tr>
       <td align="center" style="color: white; font-size: 14px;">
-        <span>&#169;</span> Copyright 2025, Vetlog.
+        <span>&#169;</span> Copyright 2026, Vetlog.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Description
Updates the year from 2025 to 2026 across all `.ftl` and `.html` templates to keep email formats current. This fulfills all acceptance criteria for the referenced issue.

### Related Issue
Resolves #34

### Execution and Testing
- [x] Globally updated target file extensions (`.ftl`, `.html`).
- [x] Executed local test suite. All tests passing.